### PR TITLE
fix: address most recent deployment rejection

### DIFF
--- a/assets/templates/images.json
+++ b/assets/templates/images.json
@@ -1,6 +1,6 @@
 {
   "assets/images/logo.png": {
-    "name": "icon.[size]",
-    "sizes": [16,32,48,128]
+    "name": "icon.",
+    "sizes": [16, 32, 48, 128]
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -42,9 +42,7 @@
     "manifest_version": 3,
     "name": "Alt Tab Shortcuts",
     "options_page": "options.html",
-    "permissions": [
-        "tabs"
-    ],
+    "permissions": [],
     "short_name": "AltTabs",
     "version": "0.0.0"
 }


### PR DESCRIPTION
# Description
Address issues causing v1.2.5 to fail webstore validation

## Changes

- Fix icon naming scheme
- Fix excessive permissions

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

N/A
